### PR TITLE
Fix error where name of node is also the name of a parent (but not root) node

### DIFF
--- a/src/main/java/io/github/townyadvanced/commentedconfiguration/CommentedConfiguration.java
+++ b/src/main/java/io/github/townyadvanced/commentedconfiguration/CommentedConfiguration.java
@@ -278,7 +278,7 @@ public class CommentedConfiguration extends YamlConfiguration {
 	 */
 	private String shrinkCurrentPath(String currentPath, int newDepth) {
 		for (int i = 0; i < depth - newDepth; i++)
-			currentPath = currentPath.replace(currentPath.substring(currentPath.lastIndexOf(".")), "");
+			currentPath = currentPath.substring(0, currentPath.lastIndexOf("."));
 		return currentPath;
 	}
 
@@ -299,9 +299,8 @@ public class CommentedConfiguration extends YamlConfiguration {
 			// at root
 			currentPath = "";
 		} else {
-			// If there is a final period, replace everything after it with nothing
-			currentPath = currentPath.replace(currentPath.substring(lastIndex), "");
-			currentPath += ".";
+			// If there is a final period, trim everything after it
+			currentPath = currentPath.substring(0, lastIndex+1);
 		}
 		return currentPath += nodeName;
 	}


### PR DESCRIPTION
This fixes errors in nodes with this format: `root.namexyz.name`

This was caused by use of currentPath.replace(node) where this path, for example, would become: `rootxyz` as `.name` would be replaced with an empty string.

All uses of replace were replaced with directly replacing currentPath with a substring, this may also be slightly more efficient given substrings were created for replacement anyway, skipping a step!

Tested by copying the class to plugin where the bug was discovered to ensure no mistakes, although it is a very simple change.

